### PR TITLE
Adds forwarded message indicator

### DIFF
--- a/Sources/ErmisChatUI/Components/ChatMessageList/ChatMessage/MessageContentView.swift
+++ b/Sources/ErmisChatUI/Components/ChatMessageList/ChatMessage/MessageContentView.swift
@@ -312,6 +312,14 @@ open class MessageContentView: _View, UIProvider, UITextViewDelegate {
     open func layout(options: MessageLayoutOptions) {
         defer {
             customCellViewInjector?.contentViewDidLayout(options: options)
+            if options.contains(.forwardedMessageIndicator) {
+                let label = UILabel()
+                label.text = "You have forwarded a message"
+                label.font = theme.fonts.caption1
+                label.textColor = theme.colors.subtitleText
+                
+                bubbleThreadFootnoteContainer.insertArrangedSubview(label, at: 0)
+            }
         }
 
         var constraintsToActivate: [NSLayoutConstraint] = []

--- a/Sources/ErmisChatUI/Components/ChatMessageList/ChatMessage/MessageLayoutOptions.swift
+++ b/Sources/ErmisChatUI/Components/ChatMessageList/ChatMessage/MessageLayoutOptions.swift
@@ -94,6 +94,9 @@ public extension MessageLayoutOption {
 
     /// If set the delivery status will be shown.
     static let deliveryStatusIndicator: Self = "deliveryStatusIndicator"
+    
+    /// If set the message will have a forwarded indicator.
+    static let forwardedMessageIndicator: Self = "forwardedMessageIndicator"
 
     /// If set all the content will have centered alignment. By default, the system messages are centered.
     ///

--- a/Sources/ErmisChatUI/Components/ChatMessageList/ChatMessage/MessageLayoutOptionsResolver.swift
+++ b/Sources/ErmisChatUI/Components/ChatMessageList/ChatMessage/MessageLayoutOptionsResolver.swift
@@ -127,6 +127,10 @@ open class MessageLayoutOptionsResolver {
         if isLastInSequence && canShowDeliveryStatus(for: message, in: channel) {
             options.insert(.deliveryStatusIndicator)
         }
+        
+        if message.isSentByCurrentUser && message.forwardChannelId != nil {
+            options.insert(.forwardedMessageIndicator)
+        }
 
         return options
     }


### PR DESCRIPTION
Adds a visual indicator to messages that have been forwarded,
improving clarity and context for users.

This change introduces a new `forwardedMessageIndicator` option
to the message layout, which displays a label indicating that the
message has been forwarded. The label is styled with the theme's
caption1 font and subtitle text color.
