### PR TITLE
fix(noti): fix NSE timeout causing fallback "You have a new notificat…

### DIFF
--- a/Sources/ErmisChat/Utils/ErmisRemoteNotificationHandler.swift
+++ b/Sources/ErmisChat/Utils/ErmisRemoteNotificationHandler.swift
@@ -178,21 +178,29 @@ public class RemoteNotificationHandler {
         func getContent(from event: Event, completion: @escaping (PushNotificationContent) -> Void) {
             switch event {
             case let event as MessageNewEventDTO:
-                // Get user'name first
+                // Get user's name first
                 getUserInfo(userId: event.user.userId, projectId: event.cid.projectId) { user in
                     self.database.write { session in
+                        let message = try? session.saveMessage(payload: event.message,
+                                                             for: event.cid,
+                                                             syncOwnReactions: false,
+                                                             cache: nil).asModel()
+                        let channel = try? session.channel(cid: event.cid)?.asModel()
 
-                        guard let message = try? session.message(id: event.message.id)?.asModel(),
-                              let channel = try? session.channel(cid: event.cid)?.asModel() else {
-                            return
+                        if let message {
+                            completion(PushNotificationContent(type: .message,
+                                                               cid: event.cid,
+                                                               message: message,
+                                                               channel: channel,
+                                                               user: user,
+                                                               event: event,
+                                                               content: self.content))
+                        } else {
+                            completion(PushNotificationContent(type: .unknown,
+                                                               cid: event.cid,
+                                                               event: event,
+                                                               content: self.content))
                         }
-                        completion(PushNotificationContent(type: .message,
-                                                           cid: event.cid,
-                                                           message: message,
-                                                           channel: channel,
-                                                           user: user,
-                                                           event: event,
-                                                           content: self.content))
                     }
                 }
             case let event as NotificationChannelCreatedEventDTO:


### PR DESCRIPTION
…ion"

- MessageNewEventDTO handler used session.message(id:) which only reads from local CoreData. When app is killed, the new message was never persisted to DB, so it always returned nil.
- The guard statement then executed `return` without calling completion(), causing NSE to hang for 30s until iOS forced a timeout and displayed generic fallback text.
- Replaced session.message(id:) with session.saveMessage(payload:) to persist the push payload into CoreData first, then read it back — consistent with MessageUpdatedEventDTO handler pattern.
- Ensured completion() is always invoked via if/else branches, eliminating any possibility of NSE timeout.